### PR TITLE
Implement webhook auth route

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhoo
 - `hooks/utils.js` - Funções para consumir APIs via `fetch` e criar um cliente PostgreSQL com `@vercel/postgres`.
 - `pages/index.js` - Página principal.
 - `pages/_app.js` - Arquivo de configuração global.
-- `pages/api/v1/webhook` - Endpoint de exemplo.
+- `pages/api/v1/webhook` - Endpoint de webhook.
 
-Este repositório contém um exemplo simples de projeto Next.js. A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhook`.
+ Este repositório contém um exemplo simples de projeto Next.js. A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhook`.
+
+### Webhook
+
+O endpoint `/api/v1/webhook` aceita requisições `POST` contendo no corpo JSON os campos `rota`, `dados`, `auth` e `remetente`. A rota inicial disponível é `auth`, que verifica se o par `auth` e `remetente` existe na tabela `auth.apikeys`. Quando ambos coincidirem o retorno será `{ authorized: true }`, caso contrário `{ authorized: false }`.
 
 
 ## Scripts

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -1,21 +1,37 @@
+import { getDbClient } from '../../../../hooks/utils';
 
-import { fetchFromApi, getDbClient } from '../../../../hooks/utils';
+async function checkAuth(apiKey, remetente) {
+  const db = getDbClient();
+  await db.connect();
+  const query = 'SELECT 1 FROM auth.apikeys WHERE apikey = $1 AND description = $2 LIMIT 1';
+  const result = await db.query(query, [apiKey, remetente]);
+  return result.rows.length > 0;
+}
 
 export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { rota, dados, auth, remetente } = req.body || {};
+
+  if (!rota || !auth || !remetente) {
+    res.status(400).json({ error: 'rota, auth and remetente are required' });
+    return;
+  }
+
   try {
-    // exemplo de uso de fetch
-    const data = await fetchFromApi('https://jsonplaceholder.typicode.com/todos/1');
-
-    // exemplo de uso do cliente do banco de dados
-    const db = getDbClient();
-    // await db.connect(); // a conexão real depende de configuração externa
-
-    res.status(200).json({ message: 'webhook endpoint', data });
+    switch (rota) {
+      case 'auth': {
+        const authorized = await checkAuth(auth, remetente);
+        res.status(200).json({ authorized });
+        break;
+      }
+      default:
+        res.status(400).json({ error: 'Unknown route' });
+    }
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
-
-export default function handler(req, res) {
-  res.status(200).json({ message: 'webhook endpoint' });
-
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 
-
 export default function Home() {
   return (
     <>


### PR DESCRIPTION
## Summary
- clean up homepage export
- implement webhook routing with auth check
- document new webhook behavior

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849aad5ea988330bc8be655b6d9e172