### PR TITLE
Implement subcategory creation route

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhoo
 - `pages/index.js` - Página principal.
 - `pages/_app.js` - Arquivo de configuração global.
 - `pages/api/v1/webhook` - Endpoint de webhook.
+- `pages/api/v1/subcategorias` - Endpoint para cadastrar subcategorias.
 
  Este repositório contém um exemplo simples de projeto Next.js. A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhook`.
 

--- a/pages/api/v1/subcategorias/index.js
+++ b/pages/api/v1/subcategorias/index.js
@@ -1,0 +1,35 @@
+import { createPool } from '@vercel/postgres';
+
+const pool = createPool({
+  connectionString: process.env.POSTGRES_URL,
+});
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { nome, categoria_id } = req.body || {};
+
+  if (!nome || !categoria_id) {
+    return res.status(400).json({ error: 'nome e categoria_id são obrigatórios' });
+  }
+
+  if (!process.env.POSTGRES_URL) {
+    return res.status(500).json({ error: 'Variável de ambiente POSTGRES_URL não definida' });
+  }
+
+  try {
+    const client = await pool.connect();
+    try {
+      const query = 'INSERT INTO afiliado.subcategorias (nome, categoria_id) VALUES ($1, $2) RETURNING id, nome, categoria_id;';
+      const result = await client.query(query, [nome, categoria_id]);
+      return res.status(201).json({ subcategoria: result.rows[0] });
+    } finally {
+      client.release();
+    }
+  } catch (error) {
+    console.error('Erro ao cadastrar subcategoria:', error);
+    return res.status(500).json({ error: 'Erro interno do servidor' });
+  }
+}


### PR DESCRIPTION
## Summary
- add API endpoint `pages/api/v1/subcategorias` for inserting subcategories
- document the new endpoint in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a09ed7210833097cbdbca0272b8f9