### PR TITLE
Add categories API route

### DIFF
--- a/pages/api/v1/categories.js
+++ b/pages/api/v1/categories.js
@@ -1,0 +1,16 @@
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // Lista estática de categorias. Substitua por consulta ao banco se necessário.
+  const categories = [
+    'Tecnologia',
+    'Educação',
+    'Saúde',
+    'Entretenimento',
+    'Negócios'
+  ];
+
+  res.status(200).json({ categories });
+}


### PR DESCRIPTION
## Summary
- add `pages/api/v1/categories.js` with GET endpoint returning static categories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0a03ce688330a78f643b16a5407f