### PR TITLE
Add subcategory API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,17 @@ A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhoo
 - `pages/index.js` - Página principal.
 - `pages/_app.js` - Arquivo de configuração global.
 - `pages/api/v1/webhook` - Endpoint de webhook.
+- `pages/api/v1/subcategorias` - Lista de subcategorias com suas categorias.
 
  Este repositório contém um exemplo simples de projeto Next.js. A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhook`.
 
 ### Webhook
 
 O endpoint `/api/v1/webhook` aceita requisições `POST` contendo no corpo JSON os campos `rota`, `dados`, `auth` e `remetente`. A rota inicial disponível é `auth`, que verifica se o par `auth` e `remetente` existe na tabela `auth.apikeys`. Quando ambos coincidirem o retorno será `{ authorized: true }`, caso contrário `{ authorized: false }`.
+
+### Subcategorias
+
+O endpoint `/api/v1/subcategorias` responde via `GET` com a lista de todas as subcategorias e suas respectivas categorias.
 
 
 ## Scripts

--- a/pages/api/v1/subcategorias/index.js
+++ b/pages/api/v1/subcategorias/index.js
@@ -1,0 +1,37 @@
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const categorias = [
+    {
+      id: 1,
+      nome: 'Tecnologia',
+      subcategorias: [
+        { id: 1, nome: 'Computadores' },
+        { id: 2, nome: 'Celulares' },
+      ],
+    },
+    {
+      id: 2,
+      nome: 'Casa',
+      subcategorias: [
+        { id: 3, nome: 'Móveis' },
+        { id: 4, nome: 'Decoração' },
+      ],
+    },
+  ];
+
+  const subcategorias = [];
+  categorias.forEach((cat) => {
+    cat.subcategorias.forEach((sub) => {
+      subcategorias.push({
+        id: sub.id,
+        nome: sub.nome,
+        categoria: { id: cat.id, nome: cat.nome },
+      });
+    });
+  });
+
+  return res.status(200).json({ subcategorias });
+}


### PR DESCRIPTION
## Summary
- add `/api/v1/subcategorias` route returning subcategories with categories
- document the new endpoint in README

## Testing
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_684a0a1495c88330a306351aaf6b04f0