### PR TITLE
Add afiliado category creation route

### DIFF
--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -1,51 +1,43 @@
 import { createPool } from '@vercel/postgres';
 
 async function query(rota, dados) {
-    if (!process.env.POSTGRES_URL) {
-      return { error: 'Variável de ambiente POSTGRES_URL não definida' };
+  if (!process.env.POSTGRES_URL) {
+    return { error: 'Variável de ambiente POSTGRES_URL não definida' };
+  }
+
+  const pool = createPool({ connectionString: process.env.POSTGRES_URL });
+  const client = await pool.connect();
+
+  try {
+    if (rota === 'auth') {
+      const { auth, remetente } = dados;
+      const query = 'SELECT 1 FROM auth.apikeys WHERE apikey = $1 AND description = $2 LIMIT 1';
+      const result = await client.query(query, [auth, remetente]);
+      return result.rows.length > 0;
     }
 
-   const cliente = createPool({
-      connectionString: process.env.POSTGRES_URL,
-    });
-    
-
-    try {
-
-        const pool = await cliente.connect();
-
-          if (rota === 'auth') {
-            try {
-              const { auth, remetente } = dados;
-             
-              // Consulta: verificar se existe um usuário com o email e senha informados
-                  const query = 'SELECT 1 FROM auth.apikeys WHERE apikey = $1 AND description = $2 LIMIT 1';
-              const result = await db.query(query, [auth, remetente]);
-              return result.rows.length > 0;
-                  } catch (error) {
-                    console.error('Erro ao autenticar usuário:', error);
-                    return { error: `Erro interno do servidor - ${error.message}` };
-                  }
-          }
-
-          
-
-      return { error: 'Rota não encontrada' , dados};
-    } catch (error) {
-      console.error('Erro ao executar a consulta:', error);
-      return { error: `Erro interno do servidor - ${error.message}` };
+    if (rota === 'cadastroCategoriaAfiliado') {
+      const { nome } = dados;
+      const query = 'INSERT INTO afiliado.categorias (nome) VALUES ($1) RETURNING id, nome';
+      const result = await client.query(query, [nome]);
+      return result.rows[0];
     }
+
+    return { error: 'Rota não encontrada', dados };
+  } catch (error) {
+    console.error('Erro ao executar a consulta:', error);
+    return { error: `Erro interno do servidor - ${error.message}` };
+  } finally {
+    client.release();
+  }
 }
-  
-  
-async function consulta(rota, dados) {
+
+export default async function consulta(rota, dados) {
   try {
     const resultado = await query(rota, dados);
     return resultado;
   } catch (error) {
     console.error('Erro na consulta:', error);
-    throw error; // Rejogue o erro para que ele seja capturado pelo caller (quem chama a função)
+    throw error;
   }
 }
-
-export default consulta;

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -51,6 +51,15 @@ export default async function webhook(req, res) {
         return res.status(200).json({ sucesso: true });
       }
 
+      case 'cadastroCategoriaAfiliado': {
+        const { nome } = dados || {};
+        if (!nome) {
+          return res.status(400).json({ error: 'nome é obrigatório' });
+        }
+        const resultado = await consultaBd('cadastroCategoriaAfiliado', { nome });
+        return res.status(200).json(resultado);
+      }
+
       default:
         return res.status(400).json({ error: 'Rota desconhecida' });
     }


### PR DESCRIPTION
## Summary
- implement `cadastroCategoriaAfiliado` case in webhook API
- add query for creating categories in Postgres

## Testing
- `npm install`
- `npm run dev` *(fails: Next.js server starts but environment missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a09d0d28c833082cfb8034d723273