### PR TITLE
Implement affiliado listing endpoints

### DIFF
--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -8,50 +8,74 @@ async function query(rota, dados) {
   const pool = createPool({ connectionString: process.env.POSTGRES_URL });
   const client = await pool.connect();
 
-          if (rota === 'auth') {
-            try {
-              const { auth, remetente } = dados;
+    try {
+      if (rota === 'auth') {
+        const { auth, remetente } = dados;
+        const query =
+          'SELECT 1 FROM auth.apikeys WHERE apikey = $1 AND description = $2 LIMIT 1';
+        const result = await client.query(query, [auth, remetente]);
+        return result.rows.length > 0;
+      }
 
-              // Consulta: verificar se existe um usuário com o email e senha informados
-              const queryText = 'SELECT 1 FROM auth.apikeys WHERE apikey = $1 AND description = $2 LIMIT 1';
-              const result = await pool.query(queryText, [auth, remetente]);
-              return result.rows.length > 0;
-            } catch (error) {
-              console.error('Erro ao autenticar usuário:', error);
-              return { error: `Erro interno do servidor - ${error.message}` };
-            }
-          }
+      if (rota === 'cadastroCategoriaAfiliado') {
+        const { nome } = dados;
+        const query =
+          'INSERT INTO afiliado.categorias (nome) VALUES ($1) RETURNING id, nome';
+        const result = await client.query(query, [nome]);
+        return result.rows[0];
+      }
 
-          if (rota === 'cadastroProdutoAfiliado') {
-            try {
-              const { id, nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, idade_minima, idade_maxima, data_criacao } = dados;
-              const queryText = `INSERT INTO afiliado.afiliacoes (id, nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, idade_minima, idade_maxima, data_criacao)
-                                 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING *`;
-              const values = [id, nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, idade_minima, idade_maxima, data_criacao];
-              const result = await pool.query(queryText, values);
-              return result.rows[0];
-            } catch (error) {
-              console.error('Erro ao cadastrar afiliado:', error);
-              return { error: `Erro interno do servidor - ${error.message}` };
-            }
-          }
+      if (rota === 'cadastroProdutoAfiliado') {
+        const {
+          id,
+          nome,
+          descricao,
+          imagem_url,
+          link_afiliado,
+          categoria_id,
+          subcategoria_id,
+          idade_minima,
+          idade_maxima,
+          data_criacao,
+        } = dados;
+        const queryText = `INSERT INTO afiliado.afiliacoes (id, nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, idade_minima, idade_maxima, data_criacao)
+                           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING *`;
+        const values = [
+          id,
+          nome,
+          descricao,
+          imagem_url,
+          link_afiliado,
+          categoria_id,
+          subcategoria_id,
+          idade_minima,
+          idade_maxima,
+          data_criacao,
+        ];
+        const result = await client.query(queryText, values);
+        return result.rows[0];
+      }
 
-  try {
-    if (rota === 'auth') {
-      const { auth, remetente } = dados;
-      const query = 'SELECT 1 FROM auth.apikeys WHERE apikey = $1 AND description = $2 LIMIT 1';
-      const result = await client.query(query, [auth, remetente]);
-      return result.rows.length > 0;
-    }
+      if (rota === 'listarCategoriaAfiliado') {
+        const query = 'SELECT id, nome FROM afiliado.categorias ORDER BY nome';
+        const result = await client.query(query);
+        return result.rows;
+      }
 
-    if (rota === 'cadastroCategoriaAfiliado') {
-      const { nome } = dados;
-      const query = 'INSERT INTO afiliado.categorias (nome) VALUES ($1) RETURNING id, nome';
-      const result = await client.query(query, [nome]);
-      return result.rows[0];
-    }
+      if (rota === 'listarSubcategoriaAfiliado') {
+        const query =
+          'SELECT id, nome, categoria_id FROM afiliado.subcategorias ORDER BY nome';
+        const result = await client.query(query);
+        return result.rows;
+      }
 
-    return { error: 'Rota não encontrada', dados };
+      if (rota === 'listarProdutosAfiliado') {
+        const query = 'SELECT * FROM afiliado.afiliacoes ORDER BY nome';
+        const result = await client.query(query);
+        return result.rows;
+      }
+
+      return { error: 'Rota não encontrada', dados };
   } catch (error) {
     console.error('Erro ao executar a consulta:', error);
     return { error: `Erro interno do servidor - ${error.message}` };

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -57,9 +57,27 @@ export default async function webhook(req, res) {
           return res.status(400).json({ error: 'nome é obrigatório' });
         }
         const resultado = await consultaBd('cadastroCategoriaAfiliado', { nome });
+        return res.status(200).json(resultado);
+      }
 
       case 'cadastroProdutoAfiliado': {
         const resultado = await consultaBd('cadastroProdutoAfiliado', dados);
+
+        return res.status(200).json(resultado);
+      }
+
+      case 'listarCategoriaAfiliado': {
+        const resultado = await consultaBd('listarCategoriaAfiliado');
+        return res.status(200).json(resultado);
+      }
+
+      case 'listarSubcategoriaAfiliado': {
+        const resultado = await consultaBd('listarSubcategoriaAfiliado');
+        return res.status(200).json(resultado);
+      }
+
+      case 'listarProdutosAfiliado': {
+        const resultado = await consultaBd('listarProdutosAfiliado');
 
         return res.status(200).json(resultado);
       }


### PR DESCRIPTION
## Summary
- add routes for listing afiliado entities
- add DB queries for categories, subcategories and products
- return results in webhook cases

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0d790a6c8330872d6a67e00699f8