### PR TITLE
Allow any origin for webhook

### DIFF
--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -20,6 +20,14 @@ async function conversaoCripto(conteudo) {
 }
 
 export default async function webhook(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }


### PR DESCRIPTION
## Summary
- update webhook API to permit CORS from any origin

## Testing
- `npm run dev` *(fails: next not found)*
- `node -e "require('./pages/api/v1/webhook/index.js'); console.log('ok')"` *(fails: cannot find module 'crypto-js')*

------
https://chatgpt.com/codex/tasks/task_e_684a102bcfa483309dcb7ca17f23fc40