### PR TITLE
Fix afiliação creation date handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ O endpoint `/api/v1/webhook` aceita requisições `POST` contendo no corpo JSON 
 
 A rota `listarSubcategoriaAfiliado` no webhook retorna todas as subcategorias e suas respectivas categorias, enquanto `cadastroSubcategoriaAfiliado` permite inserir novas subcategorias informando `nome` e `id_categoria`.
 
+### Afiliações
+
+Para cadastrar um novo produto de afiliado utilize a rota `cadastroProdutoAfiliado`.
+Não é necessário enviar o campo `data_criacao`, pois o backend registra a data de criação automaticamente com o timestamp atual do servidor.
+
 
 ## Scripts
 

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -44,8 +44,10 @@ async function query(rota, dados) {
           subcategoria_id,
           idade_minima,
           idade_maxima,
-          data_criacao,
         } = dados;
+
+        const data_criacao = new Date();
+
         const queryText = `INSERT INTO afiliado.afiliacoes (id, nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, idade_minima, idade_maxima, data_criacao)
                            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING *`;
         const values = [


### PR DESCRIPTION
## Summary
- auto-generate `data_criacao` for `cadastroProdutoAfiliado`
- document that `cadastroProdutoAfiliado` does not require a creation date

## Testing
- `npm install`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684a2f546dbc8330b725c734801b7d27