### PR TITLE
Remove category link from subcategory endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ O endpoint `/api/v1/webhook` aceita requisições `POST` contendo no corpo JSON 
 
 ### Subcategorias
 
-A rota `listarSubcategoriaAfiliado` no webhook retorna todas as subcategorias e suas respectivas categorias, enquanto `cadastroSubcategoriaAfiliado` permite inserir novas subcategorias informando `nome` e `id_categoria`.
+A rota `listarSubcategoriaAfiliado` no webhook retorna todas as subcategorias. A rota `cadastroSubcategoriaAfiliado` agora insere novas subcategorias informando apenas o campo `nome`.
 
 ### Afiliações
 

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -26,10 +26,10 @@ async function query(rota, dados) {
       }
 
       if (rota === 'cadastroSubcategoriaAfiliado') {
-        const { nome, id_categoria } = dados;
+        const { nome } = dados;
         const query =
-          'INSERT INTO afiliado.subcategorias (nome, categoria_id) VALUES ($1, $2) RETURNING id, nome, categoria_id';
-        const result = await client.query(query, [nome, id_categoria]);
+          'INSERT INTO afiliado.subcategorias (nome) VALUES ($1) RETURNING id, nome';
+        const result = await client.query(query, [nome]);
         return result.rows[0];
       }
 
@@ -74,7 +74,7 @@ async function query(rota, dados) {
 
       if (rota === 'listarSubcategoriaAfiliado') {
         const query =
-          'SELECT id, nome, categoria_id FROM afiliado.subcategorias ORDER BY nome';
+          'SELECT id, nome FROM afiliado.subcategorias ORDER BY nome';
         const result = await client.query(query);
         return result.rows;
       }

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -62,17 +62,15 @@ export default async function webhook(req, res) {
       }
 
       case 'cadastroSubcategoriaAfiliado': {
-       
-        const { nome, id_categoria } = dados || {};
-        
-        if (!nome || !id_categoria) {
-          return res.status(400).json({ error: 'nome e id_categoria são obrigatórios' });
+
+        const { nome } = dados || {};
+
+        if (!nome) {
+          return res.status(400).json({ error: 'nome é obrigatório' });
         }
 
-        console.log("AAAAAAA");
         const resultado = await consultaBd('cadastroSubcategoriaAfiliado', {
           nome,
-          id_categoria,
         });
         return res.status(200).json(resultado);
       }


### PR DESCRIPTION
## Summary
- update documentation for new subcategory behavior
- remove usage of `id_categoria` in webhook route
- update database helper queries to match schema change

## Testing
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a348629b8833096ea1b56bf21c8d9