### PR TITLE
Adicionar palavras_chaves a subcategorias

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhoo
 - `pages/_app.js` - Arquivo de configuração global.
 - `pages/api/v1/webhook` - Endpoint de webhook.
 - Rota `cadastroCategoriaAfiliado` no webhook - Endpoint para cadastrar categorias (envia `nome`, `label` e `descricao`).
-- Rota `cadastroSubcategoriaAfiliado` no webhook - Endpoint para cadastrar subcategorias (envia `nome`, `label` e `descricao`).
+- Rota `cadastroSubcategoriaAfiliado` no webhook - Endpoint para cadastrar subcategorias (envia `nome`, `label`, `descricao` e `palavras_chaves`).
 
  Este repositório contém um exemplo simples de projeto Next.js. A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhook`.
 
@@ -21,7 +21,7 @@ O endpoint `/api/v1/webhook` aceita requisições `POST` contendo no corpo JSON 
 
 ### Subcategorias
 
-A rota `listarSubcategoriaAfiliado` no webhook retorna todas as subcategorias. A rota `cadastroSubcategoriaAfiliado` agora aceita os campos `nome`, `label` e `descricao` ao cadastrar uma subcategoria.
+A rota `listarSubcategoriaAfiliado` no webhook retorna todas as subcategorias. A rota `cadastroSubcategoriaAfiliado` agora aceita os campos `nome`, `label`, `descricao` e `palavras_chaves` ao cadastrar uma subcategoria.
 
 ### Afiliações
 

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -27,10 +27,10 @@ async function query(rota, dados) {
     }
 
     if (rota === 'cadastroSubcategoriaAfiliado') {
-      const { nome, id_categoria, label, descricao } = dados;
+      const { nome, id_categoria, label, descricao, palavras_chaves } = dados;
       const query =
-        'INSERT INTO afiliado.subcategorias (nome, categoria_id, label, descricao) VALUES ($1, $2, $3, $4) RETURNING id, nome, categoria_id, label, descricao';
-      const result = await client.query(query, [nome, id_categoria, label, descricao]);
+        'INSERT INTO afiliado.subcategorias (nome, categoria_id, label, descricao, palavras_chaves) VALUES ($1, $2, $3, $4, $5) RETURNING id, nome, categoria_id, label, descricao, palavras_chaves';
+      const result = await client.query(query, [nome, id_categoria, label, descricao, palavras_chaves]);
       return result.rows[0];
     }
 
@@ -89,7 +89,7 @@ async function query(rota, dados) {
 
     if (rota === 'listarSubcategoriaAfiliado') {
       const query =
-        'SELECT id, nome, categoria_id, label, descricao FROM afiliado.subcategorias ORDER BY nome';
+        'SELECT id, nome, categoria_id, label, descricao, palavras_chaves FROM afiliado.subcategorias ORDER BY nome';
       const result = await client.query(query);
       return result.rows;
     }

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -66,7 +66,7 @@ export default async function webhook(req, res) {
       }
 
       case 'cadastroSubcategoriaAfiliado': {
-        const { nome, id_categoria, label, descricao } = dados || {};
+        const { nome, id_categoria, label, descricao, palavras_chaves } = dados || {};
         if (!nome) {
           return res.status(400).json({ error: 'nome é obrigatório' });
         }
@@ -75,6 +75,7 @@ export default async function webhook(req, res) {
           id_categoria,
           label,
           descricao,
+          palavras_chaves,
         });
         return res.status(200).json(resultado);
       }


### PR DESCRIPTION
## Summary
- aceitar `palavras_chaves` na rota `cadastroSubcategoriaAfiliado`
- inserir e listar `palavras_chaves` no banco de dados
- atualizar documentação

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a3b57efb08330bdc9487a40fa59af