### PR TITLE
Allow CORS only for approved domains

### DIFF
--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -1,6 +1,12 @@
 import CryptoJS from 'crypto-js';
 import consultaBd from './database';
 
+const allowedOrigins = [
+  'https://afiliados-uaistack.vercel.app',
+  'https://grupo-das-mamaes.vercel.app',
+  'https://campanhas-uaistack.vercel.app'
+];
+
 async function conversaoCripto(conteudo) {
   const secretKey = process.env.SECRET_KEY;
   if (!secretKey) {
@@ -20,9 +26,13 @@ async function conversaoCripto(conteudo) {
 }
 
 export default async function webhook(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  const origin = req.headers.origin;
+  if (allowedOrigins.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Vary', 'Origin');
 
   if (req.method === 'OPTIONS') {
     return res.status(200).end();


### PR DESCRIPTION
## Summary
- limit CORS access in the webhook endpoint to three authorized domains

## Testing
- `node --check pages/api/v1/webhook/index.js`


------
https://chatgpt.com/codex/tasks/task_e_684c30a31a7c833095dbca8993b49822