### PR TITLE
Add nicho field to product registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A rota `listarSubcategoriaAfiliado` no webhook retorna todas as subcategorias. A
 ### Afiliações
 
 Para cadastrar um novo produto de afiliado utilize a rota `cadastroProdutoAfiliado`.
+Agora, além dos campos já existentes, o backend aceita o campo `nicho` para indicar o nicho do produto.
 Não é necessário enviar o campo `data_criacao`, pois o backend registra a data de criação automaticamente com o timestamp atual do servidor.
 ## Documentacao de Endpoints
 
@@ -35,7 +36,7 @@ Todas as rotas utilizam o endpoint `/api/v1/webhook` com metodo `POST`. O corpo 
 - **cadastroCategoriaAfiliado**: `{ rota: "cadastroCategoriaAfiliado", dados: { nome, label, descricao }, auth, remetente }`
 - **cadastroSubcategoriaAfiliado**: `{ rota: "cadastroSubcategoriaAfiliado", dados: { nome, id_categoria, label, descricao, palavras_chave }, auth, remetente }`
 - **cadastroLeads**: `{ rota: "cadastroLeads", dados: { nome, whatsapp, origem, campanha_origem }, auth, remetente }`
-- **cadastroProdutoAfiliado**: `{ rota: "cadastroProdutoAfiliado", dados: { nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, idade_minima, idade_maxima, origem, preco, cliques, link_original, frete }, auth, remetente }`
+- **cadastroProdutoAfiliado**: `{ rota: "cadastroProdutoAfiliado", dados: { nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, nicho, idade_minima, idade_maxima, origem, preco, cliques, link_original, frete }, auth, remetente }`
 - **listarCategoriaAfiliado**: `{ rota: "listarCategoriaAfiliado", auth, remetente }`
 - **listarSubcategoriaAfiliado**: `{ rota: "listarSubcategoriaAfiliado", auth, remetente }`
 - **listarProdutosAfiliado**: `{ rota: "listarProdutosAfiliado", auth, remetente }`

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -70,6 +70,7 @@ async function query(rota, dados) {
     link_afiliado,
     categoria_id,
     subcategoria_id,
+    nicho,
     origem,
     preco,
     cliques = 0,
@@ -83,14 +84,14 @@ async function query(rota, dados) {
   const queryText = `
     INSERT INTO afiliado.afiliacoes (
       id, nome, descricao, imagem_url, link_afiliado,
-      categoria_id, subcategoria_id,
+      categoria_id, subcategoria_id, nicho,
       origem, preco, cliques, link_original, frete,
       data_criacao
     ) VALUES (
       $1, $2, $3, $4, $5,
-      $6, $7,
-      $8, $9, $10, $11, $12,
-      $13
+      $6, $7, $8,
+      $9, $10, $11, $12, $13,
+      $14
     )
     RETURNING *
   `;
@@ -103,6 +104,7 @@ async function query(rota, dados) {
     link_afiliado,
     categoria_id,
     subcategoria_id,
+    nicho,
     origem,
     preco,
     cliques,


### PR DESCRIPTION
## Summary
- allow `cadastroProdutoAfiliado` to receive the new `nicho` field
- document `nicho` in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c50242e608330bb0eed0cbeeb2bef