### PR TITLE
Remove buscarProdutosAfiliado route

### DIFF
--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -124,13 +124,6 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
-      case 'buscarProdutosAfiliado': {
-        const { nicho } = dados || {};
-        const resultado = await consultaBd('buscarProdutosAfiliado', { nicho });
-
-        return res.status(200).json(resultado);
-      }
-
       default:
         return res.status(400).json({ error: 'Rota desconhecida' });
     }


### PR DESCRIPTION
## Summary
- remove the `buscarProdutosAfiliado` route from the webhook handler

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c58be4ffc8330bb413d2e7c04df10