### PR TITLE
Handle optional nicho when listing afiliado products

### DIFF
--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -133,9 +133,18 @@ async function query(rota, dados) {
     }
 
    if (rota === 'listarProdutosAfiliado') {
-    const { nicho } = dados; // ou req.query, dependendo de onde vem o dado
-    const query = 'SELECT * FROM afiliado.afiliacoes WHERE nicho = $1 ORDER BY nome';
-    const values = [nicho];
+    const { nicho } = dados || {};
+
+    let query = 'SELECT * FROM afiliado.afiliacoes';
+    const values = [];
+
+    if (nicho) {
+      query += ' WHERE nicho = $1';
+      values.push(nicho);
+    }
+
+    query += ' ORDER BY nome';
+
     const result = await client.query(query, values);
     return result.rows;
   }

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -119,7 +119,8 @@ export default async function webhook(req, res) {
       }
 
       case 'listarProdutosAfiliado': {
-        const resultado = await consultaBd('listarProdutosAfiliado');
+        const { nicho } = dados || {};
+        const resultado = await consultaBd('listarProdutosAfiliado', { nicho });
 
         return res.status(200).json(resultado);
       }


### PR DESCRIPTION
## Summary
- allow optional `nicho` argument in the database query for `listarProdutosAfiliado`
- pass `{nicho}` from the API route so filtering is optional

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c58a064a88330865aeeead62e02b4