### PR TITLE
Fix unused import

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 function Main() {
   


### PR DESCRIPTION
## Summary
- remove unused `useEffect` from the index page

## Testing
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c58cf92f0833084ecb2ae80586291