### PR TITLE
Add environment example and setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+POSTGRES_URL=postgres://user:password@localhost:5432/dbname
+SECRET_KEY=your_secret_key
+IV=your_initialization_vector
+MANUTENCAO=sim

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 Projeto de exemplo utilizando Next.js com React.
 A página inicial exibe `Olá mundo` e há um endpoint de API em `/api/v1/webhook`.
 
+## Configuração
+
+Copie o arquivo `.env.example` para `.env` e ajuste os valores de acordo com seu ambiente. Os seguintes campos precisam ser preenchidos:
+
+- `POSTGRES_URL`
+- `SECRET_KEY`
+- `IV`
+- `MANUTENCAO`
+
 ## Estrutura
 
 - `hooks/utils.js` - Funções para consumir APIs via `fetch` e criar um cliente PostgreSQL com `@vercel/postgres`.


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholder variables
- document environment setup in README

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c58e4067083308b14a2e889e8542c