### PR TITLE
Add afiliado email lookup API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Todas as rotas utilizam o endpoint `/api/v1/webhook` com metodo `POST`. O corpo 
 - **listarSubcategoriaAfiliado**: `{ rota: "listarSubcategoriaAfiliado", auth, remetente }`
 - **listarProdutosAfiliado**: `{ rota: "listarProdutosAfiliado", auth, remetente }`
 - **buscarProdutosAfiliado**: `{ rota: "buscarProdutosAfiliado", dados: { nicho }, auth, remetente }`
+- **buscarAfiliadoPorEmail**: `{ rota: "buscarAfiliadoPorEmail", dados: { email }, auth, remetente }`
 
 ## Scripts
 

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -132,7 +132,7 @@ async function query(rota, dados) {
       return result.rows;
     }
 
-   if (rota === 'listarProdutosAfiliado') {
+  if (rota === 'listarProdutosAfiliado') {
     const { nicho } = dados || {};
 
     let query = 'SELECT * FROM afiliado.afiliacoes';
@@ -149,9 +149,16 @@ async function query(rota, dados) {
     return result.rows;
   }
 
+  if (rota === 'buscarAfiliadoPorEmail') {
+    const { email } = dados || {};
+    const query = 'SELECT nichos, admin FROM afiliado.afiliados WHERE email = $1 LIMIT 1';
+    const result = await client.query(query, [email]);
+    return result.rows[0];
+  }
 
 
-    return { error: 'Rota não encontrada', dados };
+
+  return { error: 'Rota não encontrada', dados };
   } catch (error) {
     console.error('Erro ao executar a consulta:', error);
     return { error: `Erro interno do servidor - ${error.message}` };

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -107,6 +107,16 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'buscarAfiliadoPorEmail': {
+        const { email } = dados || {};
+        if (!email) {
+          return res.status(400).json({ error: 'email é obrigatório' });
+        }
+        const resultado = await consultaBd('buscarAfiliadoPorEmail', { email });
+
+        return res.status(200).json(resultado);
+      }
+
       default:
         return res.status(400).json({ error: 'Rota desconhecida' });
     }


### PR DESCRIPTION
## Summary
- implement `buscarAfiliadoPorEmail` DB query
- expose `buscarAfiliadoPorEmail` via webhook API
- document new endpoint in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7b4a77ec833087e6404f5c54def3