### PR TITLE
Fix webhook database build error

### DIFF
--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -133,8 +133,6 @@ async function query(rota, dados) {
     }
 
   if (rota === 'listarProdutosAfiliado') {
-    const { nicho } = dados || {};
-   if (rota === 'listarProdutosAfiliado') {
     const { nicho_id } = dados || {};
 
     let query = 'SELECT * FROM afiliado.afiliacoes';


### PR DESCRIPTION
## Summary
- fix missing closing bracket in `listarProdutosAfiliado` block
- ensure `next build` succeeds

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c7f6b31fc83309ed4b3e297b6a8ce