### PR TITLE
Update afiliacao to support multiple categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A rota `listarSubcategoriaAfiliado` no webhook retorna todas as subcategorias. A
 
 Para cadastrar um novo produto de afiliado utilize a rota `cadastroProdutoAfiliado`.
 Agora, além dos campos já existentes, o backend aceita o campo `nicho_id` para indicar o nicho do produto.
+O campo `categorias` permite enviar uma lista de identificadores de categorias, possibilitando cadastrar o produto em mais de uma categoria.
 Não é necessário enviar o campo `data_criacao`, pois o backend registra a data de criação automaticamente com o timestamp atual do servidor.
 
 ## Documentacao de Endpoints
@@ -62,7 +63,7 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
   - Saida: registro inserido com `id` e `data_cadastro`
 
 - **cadastroProdutoAfiliado**
-  - Entrada: `{ nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }`
+  - Entrada: `{ nome, descricao, imagem_url, link_afiliado, categorias, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }`
   - Saida: registro inserido com `id` gerado e `data_criacao`
 
 - **listarCategoriaAfiliado**

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -66,7 +66,7 @@ async function query(rota, dados) {
         descricao,
         imagem_url,
         link_afiliado,
-        categoria_id,
+        categorias,
         subcategoria_id,
         nicho_id,
         origem,
@@ -82,7 +82,7 @@ async function query(rota, dados) {
       const queryText = `
         INSERT INTO afiliado.afiliacoes (
           id, nome, descricao, imagem_url, link_afiliado,
-          categoria_id, subcategoria_id, nicho_id,
+          categorias, subcategoria_id, nicho_id,
           origem, preco, cliques, link_original, frete,
           data_criacao
         ) VALUES (
@@ -100,7 +100,7 @@ async function query(rota, dados) {
         descricao,
         imagem_url,
         link_afiliado,
-        categoria_id,
+        categorias,
         subcategoria_id,
         nicho_id,
         origem,


### PR DESCRIPTION
## Summary
- support array of categorias in `cadastroProdutoAfiliado`
- document categoria array in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dd12b75948330898739cc7196c867