### PR TITLE
Add product update route

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
   - Entrada: `{ nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }`
   - Saida: registro inserido com `id` gerado e `data_criacao`
 
+- **atualizarProdutoAfiliado**
+  - Entrada: `{ id, nome, descricao, imagem_url, link_afiliado, categoria_id, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }`
+  - Saida: registro atualizado
+
 - **listarCategoriaAfiliado**
   - Entrada: nenhum campo em `dados`
   - Saida: lista de `{ id, nome, label, descricao }`

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -115,6 +115,61 @@ async function query(rota, dados) {
       return result.rows[0];
     }
 
+    if (rota === 'atualizarProdutoAfiliado') {
+      const {
+        id,
+        nome,
+        descricao,
+        imagem_url,
+        link_afiliado,
+        categoria_id,
+        subcategoria_id,
+        nicho_id,
+        origem,
+        preco,
+        cliques = 0,
+        link_original,
+        frete = false,
+      } = dados;
+
+      const queryText = `
+        UPDATE afiliado.afiliacoes SET
+          nome = $2,
+          descricao = $3,
+          imagem_url = $4,
+          link_afiliado = $5,
+          categoria_id = $6,
+          subcategoria_id = $7,
+          nicho_id = $8,
+          origem = $9,
+          preco = $10,
+          cliques = $11,
+          link_original = $12,
+          frete = $13
+        WHERE id = $1
+        RETURNING *
+      `;
+
+      const values = [
+        id,
+        nome,
+        descricao,
+        imagem_url,
+        link_afiliado,
+        categoria_id,
+        subcategoria_id,
+        nicho_id,
+        origem,
+        preco,
+        cliques,
+        link_original,
+        frete,
+      ];
+
+      const result = await client.query(queryText, values);
+      return result.rows[0];
+    }
+
 
     if (rota === 'listarCategoriaAfiliado') {
       const { nicho_id } = dados || {};

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -92,6 +92,12 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'atualizarProdutoAfiliado': {
+        const resultado = await consultaBd('atualizarProdutoAfiliado', dados);
+
+        return res.status(200).json(resultado);
+      }
+
       case 'listarCategoriaAfiliado': {
         
         const { nicho_id } = dados || {};


### PR DESCRIPTION
## Summary
- add `atualizarProdutoAfiliado` case in webhook API
- implement DB query to update affiliate products
- document the new update route

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dd407e49c833089578df7b381c78f