### PR TITLE
Add route for pending affiliations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Para cadastrar um novo produto de afiliado utilize a rota `cadastroProdutoAfilia
 Agora, além dos campos já existentes, o backend aceita o campo `nicho_id` para indicar o nicho do produto.
 O campo `categorias` permite enviar uma lista de identificadores de categorias, possibilitando cadastrar o produto em mais de uma categoria.
 Não é necessário enviar o campo `data_criacao`, pois o backend registra a data de criação automaticamente com o timestamp atual do servidor.
+Produtos que aguardam análise podem ser cadastrados por meio da rota `cadastroAfiliacaoPendente`, armazenando as informações na tabela `afiliacoes_pendentes`.
 
 ## Documentacao de Endpoints
 
@@ -56,6 +57,7 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
 | `cadastroSubcategoriaAfiliado` | `{ nome, label, descricao, palavras_chave, nicho_id }` | `{ id, nome, label, descricao, palavras_chave, nicho_id }` |
 | `cadastroLeads` | `{ nome, whatsapp, origem, campanha_origem }` | Registro inserido com `id` e `data_cadastro` |
 | `cadastroProdutoAfiliado` | `{ nome, descricao, imagem_url, link_afiliado, categorias, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }` | Registro inserido com `id` e `data_criacao` |
+| `cadastroAfiliacaoPendente` | `{ nome, descricao, imagem_url, link_afiliado, origem, preco, cliques?, link_original?, frete?, nicho_id }` | Registro pendente inserido |
 | `atualizarProdutoAfiliado` | `{ id, nome, descricao, imagem_url, link_afiliado, categorias, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }` | Registro atualizado |
 | `listarCategoriaAfiliado` | `{ nicho_id }` | Lista de `{ id, nome, label, descricao }` |
 | `listarSubcategoriaAfiliado` | `{ nicho_id }` | Lista de `{ id, nome, label, descricao, palavras_chave }` |

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -115,6 +115,55 @@ async function query(rota, dados) {
       return result.rows[0];
     }
 
+    if (rota === 'cadastroAfiliacaoPendente') {
+      const {
+        nome,
+        descricao,
+        imagem_url,
+        link_afiliado,
+        origem,
+        preco,
+        cliques = 0,
+        link_original,
+        frete = false,
+        nicho_id
+      } = dados;
+
+      const id = uuidv4();
+      const data_criacao = new Date();
+
+      const queryText = `
+        INSERT INTO afiliado.afiliacoes_pendentes (
+          id, nome, descricao, imagem_url, link_afiliado,
+          data_criacao, origem, preco, cliques,
+          link_original, frete, nicho_id
+        ) VALUES (
+          $1, $2, $3, $4, $5,
+          $6, $7, $8, $9,
+          $10, $11, $12
+        )
+        RETURNING *
+      `;
+
+      const values = [
+        id,
+        nome,
+        descricao,
+        imagem_url,
+        link_afiliado,
+        data_criacao,
+        origem,
+        preco,
+        cliques,
+        link_original,
+        frete,
+        nicho_id
+      ];
+
+      const result = await client.query(queryText, values);
+      return result.rows[0];
+    }
+
    if (rota === 'atualizarProdutoAfiliado') {
   const {
     id,

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -93,6 +93,12 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'cadastroAfiliacaoPendente': {
+        const resultado = await consultaBd('cadastroAfiliacaoPendente', dados);
+
+        return res.status(200).json(resultado);
+      }
+
       case 'atualizarProdutoAfiliado': {
         const resultado = await consultaBd('atualizarProdutoAfiliado', dados);
 


### PR DESCRIPTION
## Summary
- support saving pending affiliation products via `cadastroAfiliacaoPendente`
- document the new route and update README

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f06f10c088330959545c9eb8e397c