### PR TITLE
Add listing route for pending affiliations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Para cadastrar um novo produto de afiliado utilize a rota `cadastroProdutoAfilia
 Agora, além dos campos já existentes, o backend aceita o campo `nicho_id` para indicar o nicho do produto.
 O campo `categorias` permite enviar uma lista de identificadores de categorias, possibilitando cadastrar o produto em mais de uma categoria.
 Não é necessário enviar o campo `data_criacao`, pois o backend registra a data de criação automaticamente com o timestamp atual do servidor.
+Produtos que aguardam análise podem ser cadastrados por meio da rota `cadastroAfiliacaoPendente`, armazenando as informações na tabela `afiliacoes_pendentes`.
+Para consultar esses registros utilize a rota `listarAfiliacoesPendentes`, que retorna todos os produtos pendentes.
 
 ## Documentacao de Endpoints
 
@@ -56,10 +58,12 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
 | `cadastroSubcategoriaAfiliado` | `{ nome, label, descricao, palavras_chave, nicho_id }` | `{ id, nome, label, descricao, palavras_chave, nicho_id }` |
 | `cadastroLeads` | `{ nome, whatsapp, origem, campanha_origem }` | Registro inserido com `id` e `data_cadastro` |
 | `cadastroProdutoAfiliado` | `{ nome, descricao, imagem_url, link_afiliado, categorias, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }` | Registro inserido com `id` e `data_criacao` |
+| `cadastroAfiliacaoPendente` | `{ nome, descricao, imagem_url, link_afiliado, origem, preco, cliques?, link_original?, frete?, nicho_id }` | Registro pendente inserido |
 | `atualizarProdutoAfiliado` | `{ id, nome, descricao, imagem_url, link_afiliado, categorias, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }` | Registro atualizado |
 | `listarCategoriaAfiliado` | `{ nicho_id }` | Lista de `{ id, nome, label, descricao }` |
 | `listarSubcategoriaAfiliado` | `{ nicho_id }` | Lista de `{ id, nome, label, descricao, palavras_chave }` |
 | `listarProdutosAfiliado` | `{ nicho_id? }` | Lista de produtos afiliados |
+| `listarAfiliacoesPendentes` | `{ nicho_id? }` | Lista de produtos pendentes |
 | `buscarAfiliadoPorEmail` | `{ email }` | `{ nichos, admin }` |
 
 ## Scripts

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -115,6 +115,55 @@ async function query(rota, dados) {
       return result.rows[0];
     }
 
+    if (rota === 'cadastroAfiliacaoPendente') {
+      const {
+        nome,
+        descricao,
+        imagem_url,
+        link_afiliado,
+        origem,
+        preco,
+        cliques = 0,
+        link_original,
+        frete = false,
+        nicho_id
+      } = dados;
+
+      const id = uuidv4();
+      const data_criacao = new Date();
+
+      const queryText = `
+        INSERT INTO afiliado.afiliacoes_pendentes (
+          id, nome, descricao, imagem_url, link_afiliado,
+          data_criacao, origem, preco, cliques,
+          link_original, frete, nicho_id
+        ) VALUES (
+          $1, $2, $3, $4, $5,
+          $6, $7, $8, $9,
+          $10, $11, $12
+        )
+        RETURNING *
+      `;
+
+      const values = [
+        id,
+        nome,
+        descricao,
+        imagem_url,
+        link_afiliado,
+        data_criacao,
+        origem,
+        preco,
+        cliques,
+        link_original,
+        frete,
+        nicho_id
+      ];
+
+      const result = await client.query(queryText, values);
+      return result.rows[0];
+    }
+
    if (rota === 'atualizarProdutoAfiliado') {
   const {
     id,
@@ -222,8 +271,25 @@ async function query(rota, dados) {
       
 
       const result = await client.query(query, values);
-      
+
       console.log("AAA",result);
+      return result.rows;
+    }
+
+    if (rota === 'listarAfiliacoesPendentes') {
+      const { nicho_id } = dados || {};
+
+      let query = 'SELECT * FROM afiliado.afiliacoes_pendentes';
+      const values = [];
+
+      if (nicho_id) {
+        query += ' WHERE nicho_id = $1';
+        values.push(nicho_id);
+      }
+
+      query += ' ORDER BY nome';
+
+      const result = await client.query(query, values);
       return result.rows;
     }
 

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -93,6 +93,12 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'cadastroAfiliacaoPendente': {
+        const resultado = await consultaBd('cadastroAfiliacaoPendente', dados);
+
+        return res.status(200).json(resultado);
+      }
+
       case 'atualizarProdutoAfiliado': {
         const resultado = await consultaBd('atualizarProdutoAfiliado', dados);
 
@@ -117,6 +123,13 @@ export default async function webhook(req, res) {
         const { nicho_id } = dados || {};
         const resultado = await consultaBd('listarProdutosAfiliado', { nicho_id });
 
+
+        return res.status(200).json(resultado);
+      }
+
+      case 'listarAfiliacoesPendentes': {
+        const { nicho_id } = dados || {};
+        const resultado = await consultaBd('listarAfiliacoesPendentes', { nicho_id });
 
         return res.status(200).json(resultado);
       }


### PR DESCRIPTION
## Summary
- implement `listarAfiliacoesPendentes` for retrieving pending products
- expose the new route via the webhook
- document usage and update API route table

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f06f10c088330959545c9eb8e397c