### PR TITLE
Implement pending affiliation approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ O campo `categorias` permite enviar uma lista de identificadores de categorias, 
 Não é necessário enviar o campo `data_criacao`, pois o backend registra a data de criação automaticamente com o timestamp atual do servidor.
 Produtos que aguardam análise podem ser cadastrados por meio da rota `cadastroAfiliacaoPendente`, armazenando as informações na tabela `afiliacoes_pendentes`.
 Para consultar esses registros utilize a rota `listarAfiliacoesPendentes`, que retorna todos os produtos pendentes.
+Para aprovar uma afiliação em análise utilize `aprovarAfiliacaoPendente`, movendo o registro para `afiliacoes` e removendo-o da tabela de pendentes.
 
 
 ## Documentacao de Endpoints
@@ -65,6 +66,7 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
 | `listarSubcategoriaAfiliado` | `{ nicho_id }` | Lista de `{ id, nome, label, descricao, palavras_chave }` |
 | `listarProdutosAfiliado` | `{ nicho_id? }` | Lista de produtos afiliados |
 | `listarAfiliacoesPendentes` | `{ nicho_id? }` | Lista de produtos pendentes |
+| `aprovarAfiliacaoPendente` | `{ id, categorias, subcategoria_id }` | Registro aprovado movido para `afiliacoes` |
 | `buscarAfiliadoPorEmail` | `{ email }` | `{ nichos, admin }` |
 
 ## Scripts

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -134,6 +134,21 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'aprovarAfiliacaoPendente': {
+        const { id, categorias, subcategoria_id } = dados || {};
+        if (!id || !categorias || !subcategoria_id) {
+          return res.status(400).json({ error: 'id, categorias e subcategoria_id são obrigatórios' });
+        }
+
+        const resultado = await consultaBd('aprovarAfiliacaoPendente', {
+          id,
+          categorias,
+          subcategoria_id
+        });
+
+        return res.status(200).json(resultado);
+      }
+
       case 'buscarAfiliadoPorEmail': {
         const { email } = dados || {};
         if (!email) {


### PR DESCRIPTION
## Summary
- add route `aprovarAfiliacaoPendente` to move a record from `afiliacoes_pendentes` to `afiliacoes`
- expose the new route in the API webhook
- document the new route in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f097919f08330afc826d66713f325