### PR TITLE
Implement affiliate API key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
 | `listarAfiliacoesPendentes` | `{ nicho_id? }` | Lista de produtos pendentes |
 | `aprovarAfiliacaoPendente` | `{ id, categorias, subcategoria_id }` | Registro aprovado movido para `afiliacoes` |
 | `buscarAfiliadoPorEmail` | `{ email }` | `{ nichos, admin }` |
+| `validarApikeyAfiliado` | `{ apikey }` | `true` se a chave existir, senão `false` |
 
 ## Scripts
 

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -352,6 +352,13 @@ async function query(rota, dados) {
     return result.rows[0];
   }
 
+  if (rota === 'validarApikeyAfiliado') {
+    const { apikey } = dados || {};
+    const query = 'SELECT 1 FROM afiliado.afiliados WHERE apikey = $1 LIMIT 1';
+    const result = await client.query(query, [apikey]);
+    return result.rows.length > 0;
+  }
+
 
 
   return { error: 'Rota não encontrada', dados };

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -160,6 +160,15 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'validarApikeyAfiliado': {
+        const { apikey } = dados || {};
+        if (!apikey) {
+          return res.status(400).json({ error: 'apikey é obrigatório' });
+        }
+        const resultado = await consultaBd('validarApikeyAfiliado', { apikey });
+        return res.status(200).json(resultado);
+      }
+
       default:
         return res.status(400).json({ error: 'Rota desconhecida' });
     }


### PR DESCRIPTION
## Summary
- add route `validarApikeyAfiliado` in webhook
- handle new query in database functions
- document the route in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0c77a858833090c6b4e56a1359c8