### PR TITLE
Add link_original validation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Antes de inserir uma nova afiliação, o sistema consulta se o `link_original` (
 Produtos que aguardam análise podem ser cadastrados por meio da rota `cadastroAfiliacaoPendente`, armazenando as informações na tabela `afiliacoes_pendentes`.
 Para consultar esses registros utilize a rota `listarAfiliacoesPendentes`, que retorna todos os produtos pendentes.
 Para aprovar uma afiliação em análise utilize `aprovarAfiliacaoPendente`, movendo o registro para `afiliacoes` e removendo-o da tabela de pendentes.
+Para verificar se um `link_original` já foi cadastrado utilize a rota `validarLinkOriginal`.
 
 ### Links Rápidos
 
@@ -79,6 +80,7 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
 | `buscarAfiliadoPorEmail` | `{ email }` | `{ nichos, admin }` |
 | `validarApikeyAfiliado` | `{ apikey }` | `true` se a chave existir, senão `false` |
 | `validarLinkRapido` | `{ link }` | `true` se o link existir, senão `false` |
+| `validarLinkOriginal` | `{ link_original }` | `true` se o link existir, senão `false` |
 
 Ao cadastrar produtos ou afiliações pendentes, o campo `link_original` é processado para remover qualquer parte após o caractere `#`. O backend também verifica se o link tratado já está registrado; caso exista, a requisição retorna um erro informando que o cadastro já foi realizado.
 

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -357,6 +357,20 @@ async function query(rota, dados) {
       return result.rows.length > 0;
     }
 
+    if (rota === 'validarLinkOriginal') {
+      const { link_original } = dados || {};
+      const sanitizedLinkOriginal =
+        typeof link_original === 'string' ? link_original.split('#')[0] : link_original;
+      const query = `
+        SELECT 1 FROM afiliado.afiliacoes_pendentes WHERE link_original = $1
+        UNION ALL
+        SELECT 1 FROM afiliado.afiliacoes WHERE link_original = $1
+        LIMIT 1
+      `;
+      const result = await client.query(query, [sanitizedLinkOriginal]);
+      return result.rows.length > 0;
+    }
+
     if (rota === 'aprovarAfiliacaoPendente') {
       const { id, categorias, subcategoria_id } = dados;
 

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -146,6 +146,15 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'validarLinkOriginal': {
+        const { link_original } = dados || {};
+        if (!link_original) {
+          return res.status(400).json({ error: 'link_original é obrigatório' });
+        }
+        const resultado = await consultaBd('validarLinkOriginal', { link_original });
+        return res.status(200).json(resultado);
+      }
+
       case 'listarProdutosAfiliado': {
         const { nicho_id } = dados || {};
         const resultado = await consultaBd('listarProdutosAfiliado', { nicho_id });


### PR DESCRIPTION
## Summary
- check if `link_original` exists in tables
- expose `validarLinkOriginal` route in API
- document the new route

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f2087e39083308160940ee55660f4