### PR TITLE
Add new link_para_afiliar routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Copie o arquivo `.env.example` para `.env` e ajuste os valores de acordo com seu
 - Rota `cadastroCategoriaAfiliado` no webhook - Endpoint para cadastrar categorias (envia `nome`, `label` e `descricao`).
 - Rota `cadastroSubcategoriaAfiliado` no webhook - Endpoint para cadastrar subcategorias (envia `nome`, `label`, `descricao` e `palavras_chave`).
 - Rota `cadastroLeads` no webhook - Endpoint para cadastrar leads (envia `nome`, `whatsapp`, `origem` e `campanha_origem`).
+- Rota `cadastroLinkParaAfiliar` no webhook - Endpoint para cadastrar um link na tabela `link_para_afiliar`.
+- Rota `buscarLinkParaAfiliar` no webhook - Retorna um link aguardando processamento.
 
  Este repositório contém um exemplo simples de projeto Next.js. A página inicial exibe `Site em construção...` e há um endpoint de API em `/api/v1/webhook`.
 
@@ -70,6 +72,8 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
 | `cadastroProdutoAfiliado` | `{ nome, descricao, imagem_url, link_afiliado, categorias, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }` | Registro inserido com `id` e `data_criacao` |
 | `cadastroAfiliacaoPendente` | `{ nome, descricao, imagem_url, link_afiliado, origem, preco, cliques?, link_original?, frete?, nicho_id }` | Registro pendente inserido |
 | `cadastroLinkRapido` | `{ nome, link, subcategoria_id, nicho_id }` | `{ id, nome, link, subcategoria_id, nicho_id, criado_em }` |
+| `cadastroLinkParaAfiliar` | `{ link, nicho, status? }` | Registro inserido com `id` e `data_criacao` |
+| `buscarLinkParaAfiliar` | `{}` | Primeira ocorrência com `status = 'aguardando'` |
 | `atualizarProdutoAfiliado` | `{ id, nome, descricao, imagem_url, link_afiliado, categorias, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }` | Registro atualizado |
 | `listarCategoriaAfiliado` | `{ nicho_id }` | Lista de `{ id, nome, label, descricao }` |
 | `listarSubcategoriaAfiliado` | `{ nicho_id }` | Lista de `{ id, nome, label, descricao, palavras_chave }` |

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -371,6 +371,29 @@ async function query(rota, dados) {
       return result.rows.length > 0;
     }
 
+    if (rota === 'cadastroLinkParaAfiliar') {
+      const { link, nicho, status = 'aguardando' } = dados || {};
+      const query = `
+        INSERT INTO afiliado.link_para_afiliar (link, nicho, status)
+        VALUES ($1, $2, $3)
+        RETURNING id, link, nicho, status, data_criacao
+      `;
+      const result = await client.query(query, [link, nicho, status]);
+      return result.rows[0];
+    }
+
+    if (rota === 'buscarLinkParaAfiliar') {
+      const query = `
+        SELECT id, link, nicho, status, data_criacao
+        FROM afiliado.link_para_afiliar
+        WHERE status = 'aguardando'
+        ORDER BY data_criacao ASC
+        LIMIT 1
+      `;
+      const result = await client.query(query);
+      return result.rows[0];
+    }
+
     if (rota === 'aprovarAfiliacaoPendente') {
       const { id, categorias, subcategoria_id } = dados;
 

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -96,6 +96,19 @@ export default async function webhook(req, res) {
         });
         return res.status(200).json(resultado);
       }
+
+      case 'cadastroLinkParaAfiliar': {
+        const { link, nicho, status } = dados || {};
+        if (!link || !nicho) {
+          return res.status(400).json({ error: 'link e nicho são obrigatórios' });
+        }
+        const resultado = await consultaBd('cadastroLinkParaAfiliar', {
+          link,
+          nicho,
+          status,
+        });
+        return res.status(200).json(resultado);
+      }
       case 'cadastroProdutoAfiliado': {
         const resultado = await consultaBd('cadastroProdutoAfiliado', dados);
 
@@ -152,6 +165,11 @@ export default async function webhook(req, res) {
           return res.status(400).json({ error: 'link_original é obrigatório' });
         }
         const resultado = await consultaBd('validarLinkOriginal', { link_original });
+        return res.status(200).json(resultado);
+      }
+
+      case 'buscarLinkParaAfiliar': {
+        const resultado = await consultaBd('buscarLinkParaAfiliar');
         return res.status(200).json(resultado);
       }
 


### PR DESCRIPTION
## Summary
- add database functions for `link_para_afiliar`
- expose `cadastroLinkParaAfiliar` and `buscarLinkParaAfiliar` webhook routes
- document new routes in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68505b2f2d388330a846a3fdca0c5c73