### PR TITLE
Implement puppeteer session routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
 | `validarApikeyAfiliado` | `{ apikey }` | `true` se a chave existir, senão `false` |
 | `validarLinkRapido` | `{ link }` | `true` se o link existir, senão `false` |
 | `validarLinkOriginal` | `{ link_original }` | `true` se o link existir, senão `false` |
+| `salvarSessaoPuppeteer` | `{ nome, dados }` | Registro criado ou atualizado |
+| `buscarSessaoPuppeteer` | `{ nome }` | Dados da sessão solicitada |
 
 Ao cadastrar produtos ou afiliações pendentes, o campo `link_original` é processado para remover qualquer parte após o caractere `#`. O backend também verifica se o link tratado já está registrado; caso exista, a requisição retorna um erro informando que o cadastro já foi realizado.
 

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -471,6 +471,26 @@ if (rota === 'cadastroLinkParaAfiliar') {
     return result.rows.length > 0;
   }
 
+  if (rota === 'salvarSessaoPuppeteer') {
+    const { nome, dados: conteudo } = dados || {};
+    const query = `
+      INSERT INTO automacoes_puppeteer.sessoes (nome, dados)
+      VALUES ($1, $2)
+      ON CONFLICT (nome) DO UPDATE
+        SET dados = EXCLUDED.dados,
+            atualizado_em = NOW()
+      RETURNING id, nome, dados, atualizado_em, criado_em`;
+    const result = await client.query(query, [nome, conteudo]);
+    return result.rows[0];
+  }
+
+  if (rota === 'buscarSessaoPuppeteer') {
+    const { nome } = dados || {};
+    const query = 'SELECT id, nome, dados, atualizado_em, criado_em FROM automacoes_puppeteer.sessoes WHERE nome = $1 LIMIT 1';
+    const result = await client.query(query, [nome]);
+    return result.rows[0];
+  }
+
 
 
   return { error: 'Rota não encontrada', dados };

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -221,6 +221,24 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'salvarSessaoPuppeteer': {
+        const { nome, dados: conteudo } = dados || {};
+        if (!nome || !conteudo) {
+          return res.status(400).json({ error: 'nome e dados são obrigatórios' });
+        }
+        const resultado = await consultaBd('salvarSessaoPuppeteer', { nome, dados: conteudo });
+        return res.status(200).json(resultado);
+      }
+
+      case 'buscarSessaoPuppeteer': {
+        const { nome } = dados || {};
+        if (!nome) {
+          return res.status(400).json({ error: 'nome é obrigatório' });
+        }
+        const resultado = await consultaBd('buscarSessaoPuppeteer', { nome });
+        return res.status(200).json(resultado);
+      }
+
       default:
         return res.status(400).json({ error: 'Rota desconhecida' });
     }


### PR DESCRIPTION
## Summary
- add database functions for saving and fetching puppeteer sessions
- expose `salvarSessaoPuppeteer` and `buscarSessaoPuppeteer` cases in API
- document new routes in README

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850a68434608330b3ae17a27bc176f1