### PR TITLE
Add product counter update route

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Produtos que aguardam análise podem ser cadastrados por meio da rota `cadastroA
 Para consultar esses registros utilize a rota `listarAfiliacoesPendentes`, que retorna todos os produtos pendentes.
 Para aprovar uma afiliação em análise utilize `aprovarAfiliacaoPendente`, movendo o registro para `afiliacoes` e removendo-o da tabela de pendentes.
 Para verificar se um `link_original` já foi cadastrado utilize a rota `validarLinkOriginal`.
+Para registrar um clique em um produto existente use `atualizarContadorProduto` informando o `id`.
 
 ### Links Rápidos
 
@@ -77,6 +78,7 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
 | `buscarLinkParaAfiliar` | `{}` | Primeira ocorrência com `status = 'aguardando'` |
 | `deletarLinkParaAfiliar` | `{ id }` | `{ id }` do link removido |
 | `atualizarProdutoAfiliado` | `{ id, nome, descricao, imagem_url, link_afiliado, categorias, subcategoria_id, nicho_id, origem, preco, cliques?, link_original?, frete? }` | Registro atualizado |
+| `atualizarContadorProduto` | `{ id }` | `{ id, cliques }` com contador incrementado |
 | `listarCategoriaAfiliado` | `{ nicho_id }` | Lista de `{ id, nome, label, descricao }` |
 | `listarSubcategoriaAfiliado` | `{ nicho_id }` | Lista de `{ id, nome, label, descricao, palavras_chave }` |
 | `listarLinksRapidos` | `{ nicho_id }` | Lista de links rápidos |

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -264,7 +264,7 @@ async function query(rota, dados) {
     }
 
 
-   if (rota === 'atualizarProdutoAfiliado') {
+  if (rota === 'atualizarProdutoAfiliado') {
   const {
     id,
     nome,
@@ -317,6 +317,18 @@ async function query(rota, dados) {
 
   const result = await client.query(queryText, values);
   return result.rows[0];
+  }
+
+  if (rota === 'atualizarContadorProduto') {
+    const { id } = dados || {};
+    const query = `
+      UPDATE afiliado.afiliacoes
+      SET cliques = cliques + 1
+      WHERE id = $1
+      RETURNING id, cliques
+    `;
+    const result = await client.query(query, [id]);
+    return result.rows[0];
   }
 
 

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -126,6 +126,15 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'atualizarContadorProduto': {
+        const { id } = dados || {};
+        if (!id) {
+          return res.status(400).json({ error: 'id é obrigatório' });
+        }
+        const resultado = await consultaBd('atualizarContadorProduto', { id });
+        return res.status(200).json(resultado);
+      }
+
       case 'listarCategoriaAfiliado': {
         
         const { nicho_id } = dados || {};


### PR DESCRIPTION
## Summary
- add `atualizarContadorProduto` route in API
- update Postgres queries to increment `cliques`
- document new route in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852ba93872c8330a990c5ce8ba0b1b7