### PR TITLE
Implement buscarTextoParaGrupo route

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Todas as requisicoes devem usar `POST /api/v1/webhook` com o corpo JSON:
 | `validarLinkOriginal` | `{ link_original }` | `true` se o link existir, senão `false` |
 | `salvarSessaoPuppeteer` | `{ nome, dados }` | Registro criado ou atualizado |
 | `buscarSessaoPuppeteer` | `{ nome }` | Dados da sessão solicitada |
+| `buscarTextoParaGrupo` | `{ apikey }` | Primeira afiliação com texto para grupo |
 
 Ao cadastrar produtos ou afiliações pendentes, o campo `link_original` é processado para remover qualquer parte após o caractere `#`. O backend também verifica se o link tratado já está registrado; caso exista, a requisição retorna um erro informando que o cadastro já foi realizado.
 

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -266,6 +266,15 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'buscarTextoParaGrupo': {
+        const { apikey } = dados || {};
+        if (!apikey) {
+          return res.status(400).json({ error: 'apikey é obrigatório' });
+        }
+        const resultado = await consultaBd('buscarTextoParaGrupo', { apikey });
+        return res.status(200).json(resultado);
+      }
+
       default:
         return res.status(400).json({ error: 'Rota desconhecida' });
     }


### PR DESCRIPTION
## Summary
- add new route `buscarTextoParaGrupo`
- implement database query for this new route
- document the new endpoint in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852eae6ecf88330bd8afd098772b1b4