### PR TITLE
Implement scheduled GPT text generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ POSTGRES_URL=postgres://user:password@localhost:5432/dbname
 SECRET_KEY=your_secret_key
 IV=your_initialization_vector
 MANUTENCAO=sim
+CHAVE_GPT=sua_chave_openai
+BASE_LINK_CURTO=https://seulink.com/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Ao cadastrar produtos ou afiliações pendentes, o campo `link_original` é proc
 - `npm run build` – cria a aplicação para produção.
 - `npm run start` – executa a versão de produção.
 
+## Cron job
+
+Um job agendado pela Vercel executa `pages/api/v1/cron/gerarTextoParaGrupo` a cada minuto.
+Ele busca uma afiliação sem texto publicitário, gera o texto com a OpenAI utilizando
+`CHAVE_GPT` e armazena em `afiliado.afiliacoes.texto_para_grupo`.
+
 ## Licença
 
 MIT

--- a/pages/api/v1/cron/gerarTextoParaGrupo.js
+++ b/pages/api/v1/cron/gerarTextoParaGrupo.js
@@ -1,0 +1,47 @@
+import consultaBd from '../webhook/database';
+import { OpenAI } from 'openai';
+
+export default async function handler(req, res) {
+  try {
+    // busca 1 produto sem texto_para_grupo
+    const registro = await consultaBd('buscarAfiliacaoSemTexto');
+
+    if (!registro) {
+      return res.status(200).json({ message: 'Nenhuma afiliacao pendente.' });
+    }
+
+    if (!process.env.CHAVE_GPT) {
+      return res.status(500).json({ error: 'CHAVE_GPT não configurada' });
+    }
+
+    const openai = new OpenAI({ apiKey: process.env.CHAVE_GPT });
+    const linkCurto = `${process.env.BASE_LINK_CURTO || ''}${registro.codigo_curto}`;
+
+    const prompt =
+      `Gere um texto de venda empático e atrativo com até 5 parágrafos curtos,  com base nesse produto:\n` +
+      JSON.stringify({
+        nome: registro.nome,
+        descricao: registro.descricao,
+        preco: registro.preco,
+        frete: registro.frete,
+        link_curto: linkCurto,
+      }, null, 2) +
+      `\n\nFinalize com um botão de CTA assim:\n\n🛒 [QUERO ESSE PRODUTO AGORA!]\n${linkCurto}`;
+
+    const gptResponse = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const texto = gptResponse.choices?.[0]?.message?.content?.trim();
+
+    if (texto) {
+      await consultaBd('salvarTextoParaGrupo', { id: registro.id, texto });
+    }
+
+    return res.status(200).json({ id: registro.id, texto });
+  } catch (error) {
+    console.error('Erro no cron gerarTextoParaGrupo:', error);
+    return res.status(500).json({ error: error.message });
+  }
+}

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -695,6 +695,30 @@ if (rota === 'cadastroLinkParaAfiliar') {
     return result.rows[0];
   }
 
+  if (rota === 'buscarAfiliacaoSemTexto') {
+    const query = `
+      SELECT id, nome, descricao, preco, frete, codigo_curto
+      FROM afiliado.afiliacoes
+      WHERE (texto_para_grupo IS NULL OR texto_para_grupo = '')
+      ORDER BY data_criacao ASC
+      LIMIT 1
+    `;
+    const result = await client.query(query);
+    return result.rows[0];
+  }
+
+  if (rota === 'salvarTextoParaGrupo') {
+    const { id, texto } = dados || {};
+    const query = `
+      UPDATE afiliado.afiliacoes
+      SET texto_para_grupo = $2
+      WHERE id = $1
+      RETURNING id, texto_para_grupo
+    `;
+    const result = await client.query(query, [id, texto]);
+    return result.rows[0];
+  }
+
 
 
   return { error: 'Rota não encontrada', dados };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/v1/cron/gerarTextoParaGrupo",
+      "schedule": "*/1 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- create OpenAI cron API route
- extend database helpers with queries to fetch/update texto_para_grupo
- define vercel schedule
- document cron behaviour
- update environment example with GPT config

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853112f5ad48330a9db1a8df33b2c71