### PR TITLE
Consulta individual via codigo_curto

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Somente as origens listadas no código são aceitas pelo CORS:
 | `buscarLinkParaAfiliar` | `{}` | link pendente |
 | `deletarLinkParaAfiliar` | `{ id }` | link removido |
 | `listarProdutosAfiliado` | `{ nicho_id? }` | lista de produtos |
-| `buscarProdutoAfiliado` | `{ id }` | produto encontrado |
+| `buscarProdutoAfiliado` | `{ codigo_curto }` | produto encontrado |
 | `listarAfiliacoesPendentes` | `{ nicho_id? }` | produtos pendentes |
 | `aprovarAfiliacaoPendente` | `{ id, categorias, subcategoria_id }` | pendente aprovado |
 | `buscarAfiliadoPorEmail` | `{ email }` | informações do afiliado |

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -198,11 +198,11 @@ export default async function webhook(req, res) {
       }
 
       case 'buscarProdutoAfiliado': {
-        const { id } = dados || {};
-        if (!id) {
-          return res.status(400).json({ error: 'id é obrigatório' });
+        const { codigo_curto } = dados || {};
+        if (!codigo_curto) {
+          return res.status(400).json({ error: 'codigo_curto é obrigatório' });
         }
-        const resultado = await consultaBd('buscarProdutoAfiliado', { id });
+        const resultado = await consultaBd('buscarProdutoAfiliado', { codigo_curto });
         return res.status(200).json(resultado);
       }
 


### PR DESCRIPTION
## Summary
- adjust webhook to read codigo_curto instead of id
- document new parameter in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68542a5037648330adcb71ad395b3cc5