### PR TITLE
Implement click counter update by codigo_curto

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Somente as origens listadas no código são aceitas pelo CORS:
 | `cadastroAfiliacaoPendente` | mesmos campos de produto | produto pendente |
 | `atualizarProdutoAfiliado` | mesmos campos de produto mais `id` | produto atualizado |
 | `atualizarContadorProduto` | `{ id }` | contador incrementado |
+| `atualizarContadorCodigoCurto` | `{ codigo_curto }` | contador incrementado |
 | `listarCategoriaAfiliado` | `{ nicho_id }` | lista de categorias |
 | `listarSubcategoriaAfiliado` | `{ nicho_id }` | lista de subcategorias |
 | `listarLinksRapidos` | `{ nicho_id }` | links rápidos |

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -344,6 +344,18 @@ async function query(rota, dados) {
     return result.rows[0];
   }
 
+  if (rota === 'atualizarContadorCodigoCurto') {
+    const { codigo_curto } = dados || {};
+    const query = `
+      UPDATE afiliado.afiliacoes
+      SET cliques = cliques + 1
+      WHERE codigo_curto = $1
+      RETURNING id, codigo_curto, cliques
+    `;
+    const result = await client.query(query, [codigo_curto]);
+    return result.rows[0];
+  }
+
 
 
     if (rota === 'listarCategoriaAfiliado') {

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -135,6 +135,15 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'atualizarContadorCodigoCurto': {
+        const { codigo_curto } = dados || {};
+        if (!codigo_curto) {
+          return res.status(400).json({ error: 'codigo_curto é obrigatório' });
+        }
+        const resultado = await consultaBd('atualizarContadorCodigoCurto', { codigo_curto });
+        return res.status(200).json(resultado);
+      }
+
       case 'listarCategoriaAfiliado': {
         
         const { nicho_id } = dados || {};


### PR DESCRIPTION
## Summary
- support incrementing clicks using `codigo_curto`
- document new API route in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68542b77ec9883308219f2e020423b52