### PR TITLE
Fix counters and rename click route

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Somente as origens listadas no código são aceitas pelo CORS:
 | `atualizarProdutoAfiliado` | mesmos campos de produto mais `id` | produto atualizado |
 | `atualizarContadorProduto` | `{ id }` | contador incrementado |
 | `atualizarPageview` | `{ codigo_curto }` | pageview incrementado |
-| `atualizarContadorCodigoCurto` | `{ codigo_curto }` | contador incrementado |
+| `atualizarContadorCliques` | `{ codigo_curto }` | contador incrementado |
 | `listarCategoriaAfiliado` | `{ nicho_id }` | lista de categorias |
 | `listarSubcategoriaAfiliado` | `{ nicho_id }` | lista de subcategorias |
 | `listarLinksRapidos` | `{ nicho_id }` | links rápidos |

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -351,7 +351,12 @@ async function query(rota, dados) {
       SET pageview = COALESCE(pageview, 0) + 1
       WHERE codigo_curto = $1
       RETURNING id, pageview, codigo_curto
-  if (rota === 'atualizarContadorCodigoCurto') {
+    `;
+    const result = await client.query(query, [codigo_curto]);
+    return result.rows[0];
+  }
+
+  if (rota === 'atualizarContadorCliques') {
     const { codigo_curto } = dados || {};
     const query = `
       UPDATE afiliado.afiliacoes

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -136,13 +136,20 @@ export default async function webhook(req, res) {
       }
 
       case 'atualizarPageview': {
-      case 'atualizarContadorCodigoCurto': {
         const { codigo_curto } = dados || {};
         if (!codigo_curto) {
           return res.status(400).json({ error: 'codigo_curto é obrigatório' });
         }
         const resultado = await consultaBd('atualizarPageview', { codigo_curto });
-        const resultado = await consultaBd('atualizarContadorCodigoCurto', { codigo_curto });
+        return res.status(200).json(resultado);
+      }
+
+      case 'atualizarContadorCliques': {
+        const { codigo_curto } = dados || {};
+        if (!codigo_curto) {
+          return res.status(400).json({ error: 'codigo_curto é obrigatório' });
+        }
+        const resultado = await consultaBd('atualizarContadorCliques', { codigo_curto });
         return res.status(200).json(resultado);
       }
 


### PR DESCRIPTION
## Summary
- fix pageview and click counter route in database
- separate pageview and click update cases in API router
- rename `atualizarContadorCodigoCurto` to `atualizarContadorCliques`
- document new route name in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68542e09104083308be1db9f2d6c48bf