### PR TITLE
Add endpoint to fetch last active group

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Somente as origens listadas no código são aceitas pelo CORS:
 | `salvarSessaoPuppeteer` | `{ nome, dados }` | sessão salva |
 | `buscarSessaoPuppeteer` | `{ nome }` | sessão encontrada |
 | `buscarTextoParaGrupo` | `{ apikey }` | produto para divulgação (imagem em base64 opcional) |
+| `buscarUltimoGrupo` | `{ nicho }` | link convite do último grupo ativo |
 
 O endpoint `buscarTextoParaGrupo` baixa a imagem do produto e a devolve em `imagem_64` quando possível.
 

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -747,6 +747,20 @@ if (rota === 'cadastroLinkParaAfiliar') {
     return result.rows[0];
   }
 
+  if (rota === 'buscarUltimoGrupo') {
+    const { nicho } = dados || {};
+    const query = `
+      SELECT link_convite
+      FROM afiliado.grupo
+      WHERE nicho_grupo = $1
+        AND status = 'ativo'
+      ORDER BY id DESC
+      LIMIT 1
+    `;
+    const result = await client.query(query, [nicho]);
+    return result.rows[0];
+  }
+
   if (rota === 'buscarAfiliacaoSemTexto') {
     const query = `
       SELECT a.id, a.nome, a.descricao, a.preco, a.frete, a.codigo_curto, b.landingpage

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -285,6 +285,15 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'buscarUltimoGrupo': {
+        const { nicho } = dados || {};
+        if (!nicho) {
+          return res.status(400).json({ error: 'nicho é obrigatório' });
+        }
+        const resultado = await consultaBd('buscarUltimoGrupo', { nicho });
+        return res.status(200).json(resultado);
+      }
+
      case 'buscarTextoParaGrupo': {
         const { apikey } = dados || {};
         if (!apikey) {


### PR DESCRIPTION
## Summary
- implement `buscarUltimoGrupo` query in database.js
- expose `buscarUltimoGrupo` via the webhook API
- document the new route in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68545e8dcaf083308392301a42069cb6