### PR TITLE
Implement bulk link registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Somente as origens listadas no código são aceitas pelo CORS:
 | `cadastroLinkRapido` | `{ nome, link, subcategoria_id, nicho_id }` | link rápido criado |
 | `cadastroLeads` | `{ nome, whatsapp, origem?, campanha_origem? }` | lead inserido |
 | `cadastroLinkParaAfiliar` | `{ link, nicho, status?, chat_telegram? }` | registro criado |
+| `cadastroLinksParaAfiliar` | `{ nicho, links[] }` | links cadastrados em lote |
 | `cadastroProdutoAfiliado` | vários campos de produto | produto criado |
 | `cadastroAfiliacaoPendente` | mesmos campos de produto | produto pendente |
 | `atualizarProdutoAfiliado` | mesmos campos de produto mais `id` | produto atualizado |

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -527,6 +527,64 @@ if (rota === 'cadastroLinkParaAfiliar') {
   return { ok: true, ...result.rows[0] };
 }
 
+ if (rota === 'cadastroLinksParaAfiliar') {
+   const { nicho, links } = dados || {};
+
+   if (!Array.isArray(links) || links.length === 0) {
+     return { error: 'links deve ser um array' };
+   }
+
+   let chatTelegram = null;
+   if (nicho) {
+     const buscarChatQuery = `
+       SELECT chat_telegram
+       FROM afiliado.afiliados
+       WHERE $1 = ANY (nichos)
+       LIMIT 1
+     `;
+     const chatResult = await client.query(buscarChatQuery, [nicho]);
+     if (chatResult.rows.length > 0) {
+       chatTelegram = chatResult.rows[0].chat_telegram;
+     }
+   }
+
+   const resultados = [];
+   for (const link of links) {
+     const sanitized = typeof link === 'string' ? link.split('#')[0] : link;
+
+     const duplicateQuery = `
+       SELECT 1 FROM afiliado.link_para_afiliar WHERE link = $1
+       UNION ALL
+       SELECT 1 FROM afiliado.afiliacoes WHERE link_original = $1
+       UNION ALL
+       SELECT 1 FROM afiliado.afiliacoes_pendentes WHERE link_original = $1
+       LIMIT 1
+     `;
+     const dupResult = await client.query(duplicateQuery, [sanitized]);
+
+     if (dupResult.rows.length > 0) {
+       resultados.push({ link: sanitized, duplicado: true });
+       continue;
+     }
+
+     const insertQuery = `
+       INSERT INTO afiliado.link_para_afiliar (link, nicho, status, chat_telegram)
+       VALUES ($1, $2, 'aguardando', $3)
+       ON CONFLICT (link) DO NOTHING
+       RETURNING id
+     `;
+     const insertResult = await client.query(insertQuery, [sanitized, nicho, chatTelegram]);
+
+     if (insertResult.rowCount === 0) {
+       resultados.push({ link: sanitized, duplicado: true });
+     } else {
+       resultados.push({ link: sanitized, id: insertResult.rows[0].id, ok: true });
+     }
+   }
+
+   return { ok: true, resultados };
+ }
+
 
 
 

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -109,6 +109,15 @@ export default async function webhook(req, res) {
         });
         return res.status(200).json(resultado);
       }
+
+      case 'cadastroLinksParaAfiliar': {
+        const { nicho, links } = dados || {};
+        if (!nicho || !Array.isArray(links)) {
+          return res.status(400).json({ error: 'nicho e links são obrigatórios' });
+        }
+        const resultado = await consultaBd('cadastroLinksParaAfiliar', { nicho, links });
+        return res.status(200).json(resultado);
+      }
       case 'cadastroProdutoAfiliado': {
         const resultado = await consultaBd('cadastroProdutoAfiliado', dados);
 


### PR DESCRIPTION
## Summary
- add new route `cadastroLinksParaAfiliar` in API router
- handle multiple link insertion in database layer
- document the new route in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855a09d28248330aab6e9057b1dbb33