### PR TITLE
Add password recovery routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ IV=your_initialization_vector
 MANUTENCAO=sim
 CHAVE_GPT=sua_chave_openai
 BASE_LINK_CURTO=https://seulink.com/
+RESEND_KEY=sua_chave_resend
+EMAIL_FROM=Seu Nome <email@example.com>
+NOME_SITE_RECUPERACAO=https://seusite.com/recuperar/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Somente as origens listadas no código são aceitas pelo CORS:
 | `buscarSessaoPuppeteer` | `{ nome }` | sessão encontrada |
 | `buscarTextoParaGrupo` | `{ apikey }` | produto para divulgação (imagem em base64 opcional) |
 | `buscarUltimoGrupo` | `{ nicho }` | link convite do último grupo ativo |
+| `recuperarSsenha` | `{ email }` | envia código de recuperação |
+| `validarCodigoRecuperacao` | `{ email, codigo }` | boolean |
+| `atualizarSenhaRecuperacao` | `{ email, codigo, novaSenha }` | boolean |
 
 O endpoint `buscarTextoParaGrupo` baixa a imagem do produto e a devolve em `imagem_64` quando possível.
 


### PR DESCRIPTION
## Summary
- support password recovery via Resend
- document new routes
- update environment examples

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859d7bc31d88330b9d8b21e71f9db06