### PR TITLE
Add afiliado update route

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ Somente as origens listadas no código são aceitas pelo CORS:
 | `buscarProdutoAfiliado` | `{ codigo_curto }` | produto encontrado |
 | `listarAfiliacoesPendentes` | `{ nicho_id? }` | produtos pendentes |
 | `aprovarAfiliacaoPendente` | `{ id, categorias, subcategoria_id }` | pendente aprovado |
-| `buscarAfiliadoPorEmail` | `{ email, senha }` | informações do afiliado |
+| `buscarAfiliadoPorEmail` | `{ email, senha }` | dados do afiliado com horários e mensagens |
 | `validarApikeyAfiliado` | `{ apikey }` | boolean |
 | `cadastroAfiliado` | `{ email, senha }` | afiliado criado |
+| `atualizarAfiliado` | `{ id, mensagem_inicio, hora_inicio_1t, hora_fim_1t, hora_inicio_2t, hora_fim_2t, mensagem_fim, imagem_comunicado }` | afiliado atualizado |
 | `salvarSessaoPuppeteer` | `{ nome, dados }` | sessão salva |
 | `buscarSessaoPuppeteer` | `{ nome }` | sessão encontrada |
 | `buscarTextoParaGrupo` | `{ apikey }` | produto para divulgação (imagem em base64 opcional) |

--- a/pages/api/v1/webhook/database.js
+++ b/pages/api/v1/webhook/database.js
@@ -701,21 +701,57 @@ if (rota === 'cadastroLinkParaAfiliar') {
 
   if (rota === 'buscarAfiliadoPorEmail') {
     const { email, senha } = dados || {};
-    const query = 'SELECT password as senha_db, key_unic, nichos, admin FROM afiliado.afiliados WHERE email = $1 LIMIT 1';
+    const query = `
+      SELECT password as senha_db,
+             key_unic,
+             nichos,
+             admin,
+             mensagem_inicio,
+             hora_inicio_1t,
+             hora_fim_1t,
+             hora_inicio_2t,
+             hora_fim_2t,
+             mensagem_fim,
+             imagem_comunicado
+        FROM afiliado.afiliados
+       WHERE email = $1
+       LIMIT 1`;
     const result = await client.query(query, [email]);
 
     if (result.rows.length === 0) {
       return null;
     }
 
-    const { senha_db, key_unic, nichos, admin } = result.rows[0];
+    const {
+      senha_db,
+      key_unic,
+      nichos,
+      admin,
+      mensagem_inicio,
+      hora_inicio_1t,
+      hora_fim_1t,
+      hora_inicio_2t,
+      hora_fim_2t,
+      mensagem_fim,
+      imagem_comunicado
+    } = result.rows[0];
     const senhaToken = await conversaoCripto(senha + key_unic);
 
     if (senhaToken !== senha_db) {
       return null;
     }
 
-    return { nichos, admin };
+    return {
+      nichos,
+      admin,
+      mensagem_inicio,
+      hora_inicio_1t,
+      hora_fim_1t,
+      hora_inicio_2t,
+      hora_fim_2t,
+      mensagem_fim,
+      imagem_comunicado
+    };
   }
 
   if (rota === 'validarApikeyAfiliado') {
@@ -784,6 +820,45 @@ if (rota === 'cadastroLinkParaAfiliar') {
     );
 
     return true;
+  }
+
+  if (rota === 'atualizarAfiliado') {
+    const {
+      id,
+      mensagem_inicio,
+      hora_inicio_1t,
+      hora_fim_1t,
+      hora_inicio_2t,
+      hora_fim_2t,
+      mensagem_fim,
+      imagem_comunicado
+    } = dados || {};
+
+    const query = `
+      UPDATE afiliado.afiliados SET
+        mensagem_inicio = $2,
+        hora_inicio_1t = $3,
+        hora_fim_1t = $4,
+        hora_inicio_2t = $5,
+        hora_fim_2t = $6,
+        mensagem_fim = $7,
+        imagem_comunicado = $8
+      WHERE id = $1
+      RETURNING id, mensagem_inicio, hora_inicio_1t, hora_fim_1t, hora_inicio_2t, hora_fim_2t, mensagem_fim, imagem_comunicado`;
+
+    const values = [
+      id,
+      mensagem_inicio,
+      hora_inicio_1t,
+      hora_fim_1t,
+      hora_inicio_2t,
+      hora_fim_2t,
+      mensagem_fim,
+      imagem_comunicado
+    ];
+
+    const result = await client.query(query, values);
+    return result.rows[0];
   }
 
   if (rota === 'salvarSessaoPuppeteer') {

--- a/pages/api/v1/webhook/index.js
+++ b/pages/api/v1/webhook/index.js
@@ -292,6 +292,36 @@ export default async function webhook(req, res) {
         return res.status(200).json(resultado);
       }
 
+      case 'atualizarAfiliado': {
+        const {
+          id,
+          mensagem_inicio,
+          hora_inicio_1t,
+          hora_fim_1t,
+          hora_inicio_2t,
+          hora_fim_2t,
+          mensagem_fim,
+          imagem_comunicado
+        } = dados || {};
+
+        if (!id) {
+          return res.status(400).json({ error: 'id é obrigatório' });
+        }
+
+        const resultado = await consultaBd('atualizarAfiliado', {
+          id,
+          mensagem_inicio,
+          hora_inicio_1t,
+          hora_fim_1t,
+          hora_inicio_2t,
+          hora_fim_2t,
+          mensagem_fim,
+          imagem_comunicado
+        });
+
+        return res.status(200).json(resultado);
+      }
+
       case 'recuperarSsenha': {
         const { email } = dados || {};
         if (!email) {


### PR DESCRIPTION
## Summary
- add new route `atualizarAfiliado` for updating user data
- include new schedule/message fields in `buscarAfiliadoPorEmail`
- document and wire the new route in the API

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b22f3720883309e559bec52ba5ff7